### PR TITLE
Fix for Arduino on linux

### DIFF
--- a/arduino/builder.py
+++ b/arduino/builder.py
@@ -380,9 +380,9 @@ void updateTime()
 
     time.sleep(2)  # make sure glueVars.c was written to disk
 
-    # Patch POUS.c to include POUS.h and config0.h
+    # Patch POUS.c to include POUS.h and Config0.h
     f = open(base_path+'POUS.c', 'r')
-    pous_c = '#include "POUS.h"\n#include "config0.h"\n\n' + f.read()
+    pous_c = '#include "POUS.h"\n#include "Config0.h"\n\n' + f.read()
     f.close()
 
     f = open(base_path+'POUS.c', 'w')


### PR DESCRIPTION
Compiling Arduino sketch on linux fails with:

> editor/arduino/src/POUS.c:2:10: fatal error: config0.h: No such file or directory
>  #include "config0.h"
>           ^~~~~~~~~~~
> compilation terminated.

Generated files are capitalized, but the builder patches in non capitalized file names.
This works on windows, but fails on linux.


