### PR TITLE
FIXED folder tree expanding in Project Files window

### DIFF
--- a/controls/FolderTree.py
+++ b/controls/FolderTree.py
@@ -70,7 +70,7 @@ class FolderTree(wx.Panel):
             self.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self.OnTreeItemExpanded, self.Tree)
             self.Tree.Bind(wx.EVT_LEFT_DOWN, self.OnTreeLeftDown)
         else:
-            self.Bind(wx.EVT_TREE_ITEM_EXPANDED, self.OnTreeItemExpanded, self.Tree)
+            self.Bind(wx.EVT_TREE_ITEM_EXPANDING, self.OnTreeItemExpanded, self.Tree)
         self.Bind(wx.EVT_TREE_ITEM_COLLAPSED, self.OnTreeItemCollapsed, self.Tree)
         self.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.OnTreeBeginLabelEdit, self.Tree)
         self.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.OnTreeEndLabelEdit, self.Tree)


### PR DESCRIPTION
Replaced the deprecated wx.EVT_TREE_ITEM_EXPANDED event with the new one from wxPython 4 wx.EVT_TREE_ITEM_EXPANDING. This fixed a situation where the contents of a directory were not expanded when clicking on it.

**Before:
![Screenshot from 2025-06-16 16-20-21](https://github.com/user-attachments/assets/01cb39eb-b2b6-4eb1-ac6f-f880c6d00bab)

**After:
![Screenshot from 2025-06-16 16-19-53](https://github.com/user-attachments/assets/9343a0b1-0bd6-4598-b508-0240bb91f8c5)